### PR TITLE
Fix TypeError in get function

### DIFF
--- a/src/functions/get.ts
+++ b/src/functions/get.ts
@@ -16,9 +16,8 @@ interface Response {
   text: () => string;
 }
 
-export default async function post(
+export default async function get(
   url: string,
-  body: any,
   {
     secure = true,
     secureProtocol = "TLSv1_2_method",
@@ -37,7 +36,7 @@ export default async function post(
     const req = transportProtocol.request(
       url,
       {
-        method: "POST",
+        method: "GET",
         ...options,
       },
       (res) => {
@@ -70,7 +69,6 @@ export default async function post(
       reject(new Error("Request timed out"));
     });
 
-    req.write(JSON.stringify(body));
     req.end();
   });
 }


### PR DESCRIPTION
Fixes #1

Fix the TypeError related to `ERR_INVALID_ARG_TYPE` in the `get.js` file.

* Rename the function `post` to `get` in `src/functions/get.ts`.
* Remove the `body` parameter from the `get` function.
* Update the `method` option to "GET" in the `get` function.
* Remove the `req.write(JSON.stringify(body));` line from the `get` function.

