### PR TITLE
Fix error regarding the chunk of POST

### DIFF
--- a/src/functions/post.ts
+++ b/src/functions/post.ts
@@ -40,7 +40,7 @@ export default async function post(
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Content-Length": Buffer.byteLength(data),
+          "Content-Length": Buffer.byteLength(String(data)),
         },
         ...options,
       },


### PR DESCRIPTION
Fixes #3

Fix the TypeError related to the chunk of POST in the `src/functions/post.ts` file.

* Convert `data` parameter to string before calling `Buffer.byteLength`.
* Update line 43 to use `Buffer.byteLength(String(data))`.

